### PR TITLE
Bump to pydantic v2, use backwards compatible pydantic.v1

### DIFF
--- a/sdk/python/kfp/v2/components/experimental/structures.py
+++ b/sdk/python/kfp/v2/components/experimental/structures.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 from kfp.components import _components
 from kfp.components import structures as v1_structures
-import pydantic
+import pydantic.v1 as pydantic
 import yaml
 
 

--- a/sdk/python/kfp/v2/components/experimental/structures_test.py
+++ b/sdk/python/kfp/v2/components/experimental/structures_test.py
@@ -17,7 +17,7 @@ import textwrap
 import unittest
 from unittest import mock
 
-import pydantic
+import pydantic.v1 as pydantic
 from absl.testing import parameterized
 from kfp.v2.components.experimental import structures
 

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -36,6 +36,6 @@ absl-py>=0.9,<=0.11
 kfp-pipeline-spec>=0.1.16,<0.2.0
 fire>=0.3.1,<1
 google-api-python-client>=1.7.8,<2
-pydantic>=1.8.2,<2
+pydantic>=1.10.17
 dataclasses>=0.8,<1; python_version<"3.7"
 typing-extensions>=3.7.4,<5; python_version<"3.9"

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -36,6 +36,6 @@ absl-py>=0.9,<=0.11
 kfp-pipeline-spec>=0.1.16,<0.2.0
 fire>=0.3.1,<1
 google-api-python-client>=1.7.8,<2
-pydantic>=1.10.17
+pydantic>=1.10.17,<3
 dataclasses>=0.8,<1; python_version<"3.7"
 typing-extensions>=3.7.4,<5; python_version<"3.9"

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -90,7 +90,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pydantic==1.9.1
+pydantic>=1.10.17
     # via -r requirements.in
 pyparsing==3.0.9
     # via httplib2

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -90,7 +90,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pydantic>=1.10.17
+pydantic>=1.10.17,<3
     # via -r requirements.in
 pyparsing==3.0.9
     # via httplib2

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -56,7 +56,7 @@ REQUIRES = [
     'uritemplate>=3.0.1,<4',
     # pin to avoid break in requests-toolbelt due to https://github.com/psf/requests/commit/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29
     'urllib3<2',
-    'pydantic>=1.8.2,<2',
+    'pydantic>=1.10.17',
     'typer>=0.3.2,<1.0',
     # Standard library backports
     'dataclasses;python_version<"3.7"',

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -56,7 +56,7 @@ REQUIRES = [
     'uritemplate>=3.0.1,<4',
     # pin to avoid break in requests-toolbelt due to https://github.com/psf/requests/commit/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29
     'urllib3<2',
-    'pydantic>=1.10.17',
+    'pydantic>=1.10.17,<3',
     'typer>=0.3.2,<1.0',
     # Standard library backports
     'dataclasses;python_version<"3.7"',


### PR DESCRIPTION
See pydantic migration guide:
https://docs.pydantic.dev/latest/migration/